### PR TITLE
Take stream callbacks by reference

### DIFF
--- a/src/bin/test.rs
+++ b/src/bin/test.rs
@@ -57,7 +57,7 @@ fn doit()
 
 fn callback_demo()
 {
-    let callback = |&mut: _input: &[f32], output: &mut [f32], _time: stream::StreamTimeInfo, _flags: stream::StreamCallbackFlags| -> stream::StreamCallbackResult
+    let mut callback = |&mut: _input: &[f32], output: &mut [f32], _time: stream::StreamTimeInfo, _flags: stream::StreamCallbackFlags| -> stream::StreamCallbackResult
     {
         static mut lp: f32 = 0.0;
         static mut rp: f32 = 0.0;
@@ -83,12 +83,13 @@ fn callback_demo()
         stream::StreamCallbackResult::Continue
     };
 
-    let mut stream = match stream::Stream::open_default(0, 2, 44100f64, stream::FRAMES_PER_BUFFER_UNSPECIFIED, Some(box callback as stream::StreamCallback<_, _>))
+    let mut stream = match stream::Stream::open_default(0, 2, 44100f64, stream::FRAMES_PER_BUFFER_UNSPECIFIED, Some(&mut callback as &mut stream::StreamCallback<_, _>))
     {
         Err(v) => { println!("Err({})", v); return },
         Ok(stream) => stream,
     };
-    println!("finished_callback: {}", stream.set_finished_callback(box |&mut :| println!("Finished callback called")));
+    let mut finished_callback = |&mut :| println!("Finshed callback called");
+    println!("finished_callback: {}", stream.set_finished_callback(&mut finished_callback));
     println!("start: {}", stream.start());
     std::io::timer::sleep(std::time::duration::Duration::seconds(1));
     println!("stop: {}", stream.stop());


### PR DESCRIPTION
Hey Mathijs,

Not 100% sure that this is a good idea, but I think it's an improvement.  Passing the callbacks by reference means that you can call `Stream::open` within a function, passing a reference to a callback which is stored in (for example) a struct.  You can then safely return from the function without the closure going out of scope and causing Bad Things to happen.

The downside is that something like this doesn't work:

```rust
stream.set_finished_callback(&mut |&mut :| println!("Finished callback called"));
```

Instead you have to assign the callback, then pass it in:

```rust
let mut finished_callback = |&mut :| println!("Finshed callback called");
stream.set_finished_callback(&mut finished_callback);
```

Cheers,
Joe