### PR TITLE
Update libc crate to 0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,4 @@ path = "portaudio_sys"
 
 [dependencies]
 bitflags = "0.3"
-libc = "0.1"
+libc = "0.2"

--- a/portaudio_sys/Cargo.toml
+++ b/portaudio_sys/Cargo.toml
@@ -14,4 +14,4 @@ path = "lib.rs"
 pkg-config = "^0.3.3"
 
 [dependencies]
-libc = "^0.1.5"
+libc = "0.2"

--- a/src/device.rs
+++ b/src/device.rs
@@ -6,7 +6,6 @@ use hostapi::HostApiIndex;
 use pa::PaError;
 use util::Duration;
 use std::ffi::CStr;
-use std::os::raw::c_char;
 
 /// Index of a Device
 pub type DeviceIndex = u32;
@@ -48,7 +47,7 @@ impl DeviceInfo
     {
         DeviceInfo
         {
-            name: String::from_utf8_lossy(unsafe { CStr::from_ptr(input.name as *const c_char).to_bytes() }).into_owned(),
+            name: String::from_utf8_lossy(unsafe { CStr::from_ptr(input.name).to_bytes() }).into_owned(),
             host_api: input.hostApi as HostApiIndex,
             max_input_channels: input.maxInputChannels as u32,
             max_output_channels: input.maxOutputChannels as u32,

--- a/src/hostapi.rs
+++ b/src/hostapi.rs
@@ -3,7 +3,6 @@
 use ll;
 use pa::PaError;
 use std::ffi::CStr;
-use std::os::raw::c_char;
 use util::to_pa_result;
 
 /// Index number of a Host API
@@ -95,7 +94,7 @@ impl HostApiInfo
         HostApiInfo
         {
             api_type: HostApiType::from_u32(input._type),
-            name: String::from_utf8_lossy(unsafe { CStr::from_ptr(input.name as *const c_char).to_bytes() }).into_owned(),
+            name: String::from_utf8_lossy(unsafe { CStr::from_ptr(input.name).to_bytes() }).into_owned(),
             device_count: input.deviceCount as u32,
             default_input: match input.defaultInputDevice { n if n >= 0 => Some(n as u32), _ => None },
             default_output: match input.defaultOutputDevice { n if n >= 0 => Some(n as u32), _ => None },
@@ -123,7 +122,7 @@ impl HostErrorInfo
         HostErrorInfo
         {
             code: input.errorCode as i32,
-            text: String::from_utf8_lossy(unsafe { CStr::from_ptr(input.errorText as *const c_char).to_bytes() }).into_owned(),
+            text: String::from_utf8_lossy(unsafe { CStr::from_ptr(input.errorText).to_bytes() }).into_owned(),
             api_type: HostApiType::from_u32(input.hostApiType),
         }
     }

--- a/src/pa.rs
+++ b/src/pa.rs
@@ -4,7 +4,6 @@ use util::to_pa_result;
 use ll;
 use std::fmt;
 use std::ffi::CStr;
-use std::os::raw::c_char;
 
 /// PortAudio version
 pub fn version() -> i32
@@ -17,7 +16,7 @@ pub fn version() -> i32
 pub fn version_text() -> String
 {
     let version_c = unsafe { ll::Pa_GetVersionText() };
-    let version_s = String::from_utf8_lossy(unsafe { CStr::from_ptr(version_c as *const c_char).to_bytes() });
+    let version_s = String::from_utf8_lossy(unsafe { CStr::from_ptr(version_c).to_bytes() });
     version_s.into_owned()
 }
 
@@ -129,7 +128,7 @@ impl fmt::Display for PaError
             other =>
             {
                 let message_c = unsafe { ll::Pa_GetErrorText(other as i32) };
-                let message_s = String::from_utf8_lossy(unsafe { CStr::from_ptr(message_c as *const c_char).to_bytes() });
+                let message_s = String::from_utf8_lossy(unsafe { CStr::from_ptr(message_c).to_bytes() });
                 f.write_str(&*message_s)
             }
         }


### PR DESCRIPTION
Everything still builds without warnings
This also makes the casts introduced in e1349a9a753d5e5fd2edc17a8b8b3074d0be8177 superfluous and reverts them as `libc::c_char` (some members in portaudio_sys are defined as such) and `os::raw::c_char` ([as required by `CStr::from_ptr`](https://doc.rust-lang.org/nightly/std/ffi/struct.CStr.html#method.from_ptr)) are now the same