### PR TITLE
Public duration

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,7 @@ extern crate libc;
 extern crate portaudio_sys as ll;
 
 pub use pa::{PaError, PaResult, initialize, terminate, version, version_text};
+pub use util::Duration;
 
 pub mod stream;
 mod pa;

--- a/src/util.rs
+++ b/src/util.rs
@@ -23,16 +23,19 @@ pub fn duration_to_pa_time(duration: Duration) -> f64
 }
 
 mod duration {
+    /// Time duration in milliseconds
     #[derive(Copy, Clone)]
     pub struct Duration {
         ms: i64,
     }
 
     impl Duration {
+        /// Returns the duration's number of milliseconds
         pub fn num_milliseconds(&self) -> i64 {
             self.ms
         }
 
+        /// Constructs a new duration with the specified number of milliseconds
         pub fn milliseconds(milliseconds: i64) -> Duration {
             Duration { ms: milliseconds }
         }


### PR DESCRIPTION
Make Duration struct public. This is needed since Duration is used in StreamParameters. I'm new to Rust and am willing to update the pull request if there is a better way to implement the fix.