### PR TITLE
Update example in readme to work with Rust 2018

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ extern crate portaudio_rs as portaudio;
 
 fn demo() -> portaudio::PaResult
 {
-    let stream = try!(portaudio::stream::Stream::open_default(
+    let stream = portaudio::stream::Stream::open_default(
                           0, // input channels
                           1, // output channels
                           44100.0, // sample rate
                           portaudio::stream::FRAMES_PER_BUFFER_UNSPECIFIED,
                           None // no callback
-                     ));
+                 )?;
 
-    try!(stream.start());
+    stream.start()?;
 
     let mut phase = 0.0f32;
     let mut buffer = Vec::with_capacity(44100);
-    for _i in (0..44100)
+    for _i in 0..44100
     {
         // Small amplitude such that the test does not produce sound
         buffer.push(phase * 0.001);
@@ -38,7 +38,7 @@ fn demo() -> portaudio::PaResult
         if phase > 1.0 { phase -= 2.0; }
     }
 
-    try!(stream.write(&buffer));
+    stream.write(&buffer)?;
 
     Ok(())
 }


### PR DESCRIPTION
- `try!` -> `?` operator
- remove superfluous parentheses in for statement

Fixes #22 